### PR TITLE
Minor: Clarify timestamp in resampling docs

### DIFF
--- a/proto/frequenz/api/reporting/v1/reporting.proto
+++ b/proto/frequenz/api/reporting/v1/reporting.proto
@@ -95,8 +95,8 @@ message TimeFilter {
 // If data is resampled, all samples that fall in a left-closed time interval
 // determined by the resolution will be aggregated.
 // At the moment only mean aggregation is supported.
-// The timestamp of the aggregated sample corresponds to the oldest
-// possible timestamp of the time interval.
+// The timestamp for each aggregated sample represents the beginning of its corresponding
+// time interval, marking the earliest point from which data was aggregated.
 message ResamplingOptions {
   // Optional resampling resolution for the data, represented in seconds.
   // If omitted, data will be returned in its original resolution.


### PR DESCRIPTION
The previous doc on the timestamp of the resampled data was confusing.