### PR TITLE
Fix doc for end time filter

### DIFF
--- a/proto/frequenz/api/reporting/v1/reporting.proto
+++ b/proto/frequenz/api/reporting/v1/reporting.proto
@@ -67,8 +67,8 @@ message TimeFilter {
   // Optional UTC end time for the query.
   //
   // !!! info
-  //     If not provided, the query defaults to the most recent available data for the
-  //     specified microgrid components.
+  //     If not provided, the query will retrieve the requested data and continue
+  //     streaming all new data as it becomes available.
   google.protobuf.Timestamp end = 2;
 }
 


### PR DESCRIPTION
If no end date is requested, the query should return all requested data and continue streaming data as it becomes available.