### PR TITLE
Widen dependency range for common API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.5, < 0.7.0",
+  "frequenz-api-common >= 0.6.5, < 0.9.0",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major


### PR DESCRIPTION
Support up to v0.8.x is added, breaking changes in the `v1alpha8` package of the latest common API release will be addressed in a later PR.